### PR TITLE
extra kwargs for get_format_instructions

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 langchain>=0.0.202
 setuptools>=67.8.0
-pydantic>=1.10.9
+pydantic>=1.10.9,<2
 bump2version>=1.0.1
 jinja2>=3.1.2

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -94,6 +94,15 @@ class TestThoughtsJSONParser(unittest.TestCase):
         ).get_format_instructions()
         self.assertTrue('"thought1": string [Thought 1]\n\t"thought2": int [Thought 2]' in format_instructions)
 
+    def test_complex_format_instructions(self):
+        thoughts = [
+            Thought(name="tool", description="One of [{{tools}}]"),
+        ]
+        format_instructions = ThoughtsJSONParser(
+            thoughts=thoughts
+        ).get_format_instructions(tools="tool1, tool2")
+        self.assertTrue(format_instructions, '"tool": string [One of [tool1, tool2]]' in format_instructions)
+
     def test_raise_without_thoughts(self):
         with self.assertRaises(ValidationError):
             ThoughtsJSONParser(thoughts=[])

--- a/yid_langchain_extensions/output_parser/thoughts_json_parser.py
+++ b/yid_langchain_extensions/output_parser/thoughts_json_parser.py
@@ -63,7 +63,10 @@ class ThoughtsJSONParser(BaseOutputParser):
             f'"{thought.name}": {thought.type} [{thought.description}]' for thought in self.thoughts
         ])
 
-    def get_format_instructions(self) -> str:
-        format_instructions = PromptTemplate.from_template(self.format_prompt, template_format="jinja2").format_prompt(
-            thoughts=self.format_thoughts()).to_string()
+    def get_format_instructions(self, **kwargs) -> str:
+        """
+        :param kwargs: If your thoughts or format_prompt have some extra placeholders, you can fill them by kwargs
+        """
+        format_instructions = PromptTemplate.from_template(self.format_prompt, template_format="jinja2").partial(
+            thoughts=self.format_thoughts()).format_prompt(**kwargs).to_string()
         return format_instructions


### PR DESCRIPTION
When using get_format_instructions with complex thoughts (that itself has jinja2 placeholders), I need to second time format `format_instructions` to avoid such double formatting I suggest to pass values for these placeholders as kwargs of get_format_instructions