### PR TITLE
Handle starting quotes in json parser

### DIFF
--- a/tests/test_thoughts_json_parser.py
+++ b/tests/test_thoughts_json_parser.py
@@ -60,3 +60,12 @@ class TestThoughtsJSONParser(TestCase):
 }"""
         fixed = ThoughtsJSONParser.fix_json_md_snippet(text)
         self.assertEqual(fixed, self.json_md_snippet)
+
+    def test_fix_json_md_snippet_extra_quotes(self):
+        text = """"
+{
+    "thought1": "thought 1",
+    "thought2": 2
+}"""
+        fixed = ThoughtsJSONParser.fix_json_md_snippet(text)
+        self.assertEqual(fixed, self.json_md_snippet)

--- a/yid_langchain_extensions/output_parser/action_parser.py
+++ b/yid_langchain_extensions/output_parser/action_parser.py
@@ -7,7 +7,6 @@ from langchain.schema import AgentAction
 from yid_langchain_extensions.output_parser.thoughts_json_parser import Thought, ThoughtsJSONParser
 
 
-@dataclass
 class ActionWithThoughts(AgentAction):
     all_thoughts: Dict[str, Any]
 

--- a/yid_langchain_extensions/output_parser/thoughts_json_parser.py
+++ b/yid_langchain_extensions/output_parser/thoughts_json_parser.py
@@ -37,7 +37,10 @@ class ThoughtsJSONParser(BaseOutputParser):
 
     @staticmethod
     def fix_json_md_snippet(text: str) -> str:
-        fixed_json = text.strip()
+        fixed_json = text
+        if fixed_json.startswith("'") or fixed_json.startswith('"'):
+            fixed_json = fixed_json[1:]
+        fixed_json = fixed_json.strip()
         fixed_json = escape_new_lines_in_json_values(fixed_json)
         fixed_json = close_all_curly_brackets(fixed_json)
         if "```json" in fixed_json:


### PR DESCRIPTION
LLM sometimes may start output not from ```json, but from "```json. Removing of trainling quotes added + test for such case