### PR TITLE
fix requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-langchain>=0.0.202
+langchain>=0.0.315
 setuptools>=67.8.0
 pydantic>=1.10.9,<2
 bump2version>=1.0.1


### PR DESCRIPTION
Because of moving from dataclasses to pydantic, we need to bump minimum requirements