### PR TITLE
pydantic_v1_port

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -4,3 +4,4 @@ exclude =
     .git,
     __pycache__,
     venv
+    .venv

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-langchain>=0.0.315
+langchain>=0.1,<0.2
 setuptools>=67.8.0
 pydantic>=2
 bump2version>=1.0.1

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -20,10 +20,8 @@ class TestPydanticV1Port(TestCase):
         self.llm = FakeListLLM(responses=[])
 
     def test_v1_port(self):
-        llm = FakeListLLM(responses=[])
         Pydantic2ClassWithPort(llm=self.llm)
 
     def test_port_required(self):
-        llm = FakeListLLM(responses=[])
         with self.assertRaises(TypeError):
             Pydantic2ClassWithoutPort(llm=self.llm)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,29 @@
+from unittest import TestCase
+
+from langchain_community.llms.fake import FakeListLLM
+from langchain_core.language_models import LLM
+from pydantic import BaseModel
+
+from yid_langchain_extensions.utils import pydantic_v1_port
+
+
+class Pydantic2ClassWithoutPort(BaseModel):
+    llm: LLM
+
+
+class Pydantic2ClassWithPort(BaseModel):
+    llm: pydantic_v1_port(LLM)
+
+
+class TestPydanticV1Port(TestCase):
+    def setUp(self):
+        self.llm = FakeListLLM(responses=[])
+
+    def test_v1_port(self):
+        llm = FakeListLLM(responses=[])
+        Pydantic2ClassWithPort(llm=self.llm)
+
+    def test_port_required(self):
+        llm = FakeListLLM(responses=[])
+        with self.assertRaises(TypeError):
+            Pydantic2ClassWithoutPort(llm=self.llm)

--- a/yid_langchain_extensions/utils.py
+++ b/yid_langchain_extensions/utils.py
@@ -1,0 +1,14 @@
+from typing import Annotated, Type, Any
+
+from pydantic import ValidationError, PlainValidator
+from pydantic.v1 import BaseModel as BaseModelV1
+
+
+def validated(value: BaseModelV1, target_class: Type[Any]) -> BaseModelV1:
+    if isinstance(value, target_class):
+        return value
+    raise ValidationError("Input of invalid type")
+
+
+def pydantic_v1_port(cls):
+    return Annotated[cls, PlainValidator(lambda val: validated(val, cls))]


### PR DESCRIPTION
now it is possible to use langchain objects as fields of pydantic v2 class